### PR TITLE
Work manager

### DIFF
--- a/android/.settings/org.eclipse.buildship.core.prefs
+++ b/android/.settings/org.eclipse.buildship.core.prefs
@@ -1,2 +1,13 @@
+arguments=
+auto.sync=false
+build.scans.enabled=false
+connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
 connection.project.dir=
 eclipse.preferences.version=1
+gradle.user.home=
+java.home=/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
+jvm.arguments=
+offline.mode=false
+override.workspace.settings=true
+show.console.view=true
+show.executions.view=true

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,6 +76,7 @@ dependencies {
     api 'com.snappydb:snappydb-lib:0.5.2'
     api 'com.esotericsoftware.kryo:kryo:2.24.0'
     implementation 'com.google.android.gms:play-services-location:17.0.0'
+    implementation "androidx.work:work-runtime:2.3.4"
 }
 
 def configureReactNativePom(def pom) {

--- a/android/src/main/java/me/kiano/BackgroundGeofencingModule.java
+++ b/android/src/main/java/me/kiano/BackgroundGeofencingModule.java
@@ -1,5 +1,11 @@
 package me.kiano;
 
+import android.Manifest;
+import android.content.pm.PackageManager;
+import android.util.Log;
+
+import androidx.core.app.ActivityCompat;
+
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -24,7 +30,18 @@ public class BackgroundGeofencingModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void add(ReadableMap geoFence, final Promise promise) {
         try {
+
+            int permission = ActivityCompat.checkSelfPermission(getReactApplicationContext(), Manifest.permission.ACCESS_FINE_LOCATION);
+
+            Log.v("BackgroundGeofencing", "permission: " + permission);
+
+            if (permission != PackageManager.PERMISSION_GRANTED) {
+                promise.reject("permission_denied", "Access fine location is not permitted");
+                return;
+            }
+
             final RNGeofence rnGeofence = new RNGeofence(getReactApplicationContext(), geoFence);
+
             rnGeofence.start(rnGeofence.registerOnDeviceRestart, new RNGeofenceHandler() {
                 @Override
                 public void onSuccess(String geofenceId) {
@@ -38,6 +55,11 @@ public class BackgroundGeofencingModule extends ReactContextBaseJavaModule {
         } catch (Exception e) {
             promise.reject("geofence_exception", "Failed to start geofence service for id: " + geoFence.getString("id"), e);
         }
+    }
+
+    @ReactMethod
+    public void remove(String id) {
+        RNGeofence.remove(getReactApplicationContext(), id);
     }
 
     @ReactMethod

--- a/android/src/main/java/me/kiano/BackgroundGeofencingModule.java
+++ b/android/src/main/java/me/kiano/BackgroundGeofencingModule.java
@@ -1,26 +1,14 @@
 package me.kiano;
 
-import android.app.PendingIntent;
-import android.content.Intent;
-
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
-import com.google.android.gms.location.Geofence;
-import com.google.android.gms.location.GeofencingClient;
-import com.google.android.gms.location.GeofencingRequest;
-import com.google.android.gms.location.LocationServices;
-import com.google.android.gms.tasks.OnFailureListener;
-import com.google.android.gms.tasks.OnSuccessListener;
 
-import java.util.ArrayList;
-
-import me.kiano.database.GeofenceDB;
 import me.kiano.interfaces.RNGeofenceHandler;
-import me.kiano.receivers.GeofenceBroadcastReceiver;
 import me.kiano.models.RNGeofence;
+import me.kiano.models.RNGeofenceWebhookConfiguration;
 
 public class BackgroundGeofencingModule extends ReactContextBaseJavaModule {
 
@@ -37,7 +25,7 @@ public class BackgroundGeofencingModule extends ReactContextBaseJavaModule {
     public void add(ReadableMap geoFence, final Promise promise) {
         try {
             final RNGeofence rnGeofence = new RNGeofence(getReactApplicationContext(), geoFence);
-            rnGeofence.start(rnGeofence.initialiseOnDeviceRestart, new RNGeofenceHandler() {
+            rnGeofence.start(rnGeofence.registerOnDeviceRestart, new RNGeofenceHandler() {
                 @Override
                 public void onSuccess(String geofenceId) {
                     promise.resolve(geofenceId);
@@ -50,6 +38,13 @@ public class BackgroundGeofencingModule extends ReactContextBaseJavaModule {
         } catch (Exception e) {
             promise.reject("geofence_exception", "Failed to start geofence service for id: " + geoFence.getString("id"), e);
         }
+    }
+
+    @ReactMethod
+    public void configureWebhook (ReadableMap configureWebhook, final Promise promise) {
+        RNGeofenceWebhookConfiguration rnGeofenceWebhookConfiguration = new RNGeofenceWebhookConfiguration(configureWebhook);
+        rnGeofenceWebhookConfiguration.save(getReactApplicationContext());
+        promise.resolve(true);
     }
 
 }

--- a/android/src/main/java/me/kiano/database/RNGeofenceDB.java
+++ b/android/src/main/java/me/kiano/database/RNGeofenceDB.java
@@ -36,7 +36,6 @@ public class RNGeofenceDB {
             db.put(GEOFENCE_KEY_PREFIX + rnGeofence.id, rnGeofence.toJSON());
             db.close();
             Log.v(TAG, "Geofence successfully saved to DB: " + rnGeofence.id);
-            getAllGeofences();
         } catch (Exception e) {
             Log.e(TAG, e.getMessage());
         }

--- a/android/src/main/java/me/kiano/database/RNGeofenceDB.java
+++ b/android/src/main/java/me/kiano/database/RNGeofenceDB.java
@@ -5,7 +5,9 @@ import android.util.Log;
 
 import com.snappydb.DB;
 import com.snappydb.DBFactory;
+import com.snappydb.SnappydbException;
 
+import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
@@ -83,6 +85,26 @@ public class RNGeofenceDB {
             Log.v(TAG, "Geofence Webhook successfully saved to DB: " + rnGeofenceWebhookConfiguration.toJSON() + " stored: " + stored.getUrl());
         } catch (Exception e) {
             Log.e(TAG, e.getMessage());
+        }
+    }
+
+    public RNGeofenceWebhookConfiguration getWebhookConfiguration () throws JSONException, SnappydbException {
+        try {
+            DB db = DBFactory.open(context, DB_NAME);
+            RNGeofenceWebhookConfiguration rnGeofenceWebhookConfiguration = new RNGeofenceWebhookConfiguration(new JSONObject(db.get(WEBHOOK_CONFIG_KEY)));
+            db.close();
+            return rnGeofenceWebhookConfiguration;
+        } catch (Exception e) {
+            throw e;
+        }
+    }
+
+    public boolean hasWebhookConfiguration() {
+        try {
+            DB db = DBFactory.open(context, DB_NAME);
+            return db.exists(WEBHOOK_CONFIG_KEY);
+        } catch (Exception e) {
+            return false;
         }
     }
 }

--- a/android/src/main/java/me/kiano/models/RNGeofence.java
+++ b/android/src/main/java/me/kiano/models/RNGeofence.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
 
-import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReadableMap;
 import com.google.android.gms.location.Geofence;
 import com.google.android.gms.location.GeofencingClient;
@@ -18,10 +17,8 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
 
-import me.kiano.database.GeofenceDB;
+import me.kiano.database.RNGeofenceDB;
 import me.kiano.interfaces.RNGeofenceHandler;
 import me.kiano.receivers.GeofenceBroadcastReceiver;
 
@@ -35,7 +32,7 @@ public class RNGeofence {
     public final int notificationResponsiveness;
     public final int loiteringDelay;
     public final int dwellTransitionType;
-    public final boolean initialiseOnDeviceRestart;
+    public final boolean registerOnDeviceRestart;
     public final boolean setInitialTriggers;
     private final Context context;
     private final ArrayList<Geofence> geofenceList = new ArrayList<>();
@@ -54,7 +51,7 @@ public class RNGeofence {
         notificationResponsiveness = geoFence.getInt("notificationResponsiveness");
         loiteringDelay = geoFence.getInt("loiteringDelay");
         dwellTransitionType = geoFence.getInt("dwellTransitionType");
-        initialiseOnDeviceRestart = geoFence.getBoolean("initialiseOnDeviceRestart");
+        registerOnDeviceRestart = geoFence.getBoolean("registerOnDeviceRestart");
         setInitialTriggers = geoFence.getBoolean("setInitialTriggers");
         setUpRNGeofence();
     }
@@ -70,7 +67,7 @@ public class RNGeofence {
         loiteringDelay = geoFence.getInt("loiteringDelay");
         dwellTransitionType = geoFence.getBoolean("setDwellTransitionType") ? Geofence.GEOFENCE_TRANSITION_DWELL : 0;
         expirationDate = expiration > Geofence.NEVER_EXPIRE ? System.currentTimeMillis() + expiration : Geofence.NEVER_EXPIRE;
-        initialiseOnDeviceRestart = geoFence.getBoolean("initialiseOnDeviceRestart");
+        registerOnDeviceRestart = geoFence.getBoolean("registerOnDeviceRestart");
         setInitialTriggers = geoFence.getBoolean("setInitialTriggers");
         setUpRNGeofence();
     }
@@ -114,7 +111,7 @@ public class RNGeofence {
     }
 
     private void saveToDB() {
-        GeofenceDB db = new GeofenceDB(context);
+        RNGeofenceDB db = new RNGeofenceDB(context);
         db.saveGeofence(this);
     }
 
@@ -152,7 +149,7 @@ public class RNGeofence {
         json.put("notificationResponsiveness", notificationResponsiveness);
         json.put("loiteringDelay", loiteringDelay);
         json.put("dwellTransitionType", dwellTransitionType);
-        json.put("initialiseOnDeviceRestart", initialiseOnDeviceRestart);
+        json.put("registerOnDeviceRestart", registerOnDeviceRestart);
         json.put("setInitialTriggers", setInitialTriggers);
         Log.v( "RNGeofenceJSON",json.toString(2));
         return json.toString();

--- a/android/src/main/java/me/kiano/models/RNGeofence.java
+++ b/android/src/main/java/me/kiano/models/RNGeofence.java
@@ -17,6 +17,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import me.kiano.database.RNGeofenceDB;
 import me.kiano.interfaces.RNGeofenceHandler;
@@ -39,6 +40,16 @@ public class RNGeofence {
     private GeofencingClient geofencingClient;
     private PendingIntent geofencePendingIntent;
     private final String TAG = "RNGeofence";
+
+    public static void remove(Context context,String id) {
+        GeofencingClient geofencingClient = LocationServices.getGeofencingClient(context);
+        List<String> ids = new ArrayList<String>();
+        RNGeofenceDB rnGeofenceDB = new RNGeofenceDB(context);
+        ids.add(id);
+        geofencingClient.removeGeofences(ids);
+        rnGeofenceDB.removeGeofence(id);
+        Log.v("RNGeofence", "Geofence successfully removed from client and DB :)");
+    }
 
     public RNGeofence (Context context, JSONObject geoFence) throws JSONException {
         this.context = context;

--- a/android/src/main/java/me/kiano/models/RNGeofenceData.java
+++ b/android/src/main/java/me/kiano/models/RNGeofenceData.java
@@ -51,7 +51,7 @@ public class RNGeofenceData {
         }
     }
 
-    private String generateErrorMessage (String errorMessage) {
+    private String generateErrorMessage(String errorMessage) {
         try {
             JSONObject jsonObject = new JSONObject();
             jsonObject.put("geofenceIds", new JSONArray(geofenceIds));

--- a/android/src/main/java/me/kiano/models/RNGeofenceWebhookConfiguration.java
+++ b/android/src/main/java/me/kiano/models/RNGeofenceWebhookConfiguration.java
@@ -21,17 +21,18 @@ public class RNGeofenceWebhookConfiguration {
     private long timeout;
     private ArrayList<Object> exclude;
     private HashMap<String, Object> headersHashMap;
+    private long DEFAULT_TIMEOUT = 15000;
 
     public RNGeofenceWebhookConfiguration(ReadableMap configuration) {
         url = configuration.hasKey("url") ? configuration.getString("url") : null;
         headersHashMap = configuration.hasKey("headers") ? configuration.getMap("headers").toHashMap() : new HashMap<String, Object>();
-        timeout = configuration.hasKey("timeout") ? configuration.getInt("timeout") : 15000;
+        timeout = configuration.hasKey("timeout") ? configuration.getInt("timeout") : DEFAULT_TIMEOUT;
         exclude = configuration.hasKey("exclude") ? configuration.getArray("exclude").toArrayList() : new ArrayList<>();
     }
 
     public RNGeofenceWebhookConfiguration (JSONObject configuration) throws JSONException {
         url = configuration.has("url") ? configuration.getString("url") : null;
-        timeout = configuration.has("timeout") ? configuration.getLong("timeout") : 15000;
+        timeout = configuration.has("timeout") ? configuration.getLong("timeout") : DEFAULT_TIMEOUT;
         headersHashMap = new HashMap<>();
         exclude = new ArrayList<Object>();
         JSONArray excludeJSONArray = configuration.has("exclude") ? configuration.getJSONArray("exclude") : new JSONArray();

--- a/android/src/main/java/me/kiano/models/RNGeofenceWebhookConfiguration.java
+++ b/android/src/main/java/me/kiano/models/RNGeofenceWebhookConfiguration.java
@@ -1,0 +1,91 @@
+package me.kiano.models;
+
+import android.content.Context;
+
+import com.facebook.react.bridge.ReadableMap;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import me.kiano.database.RNGeofenceDB;
+import okhttp3.Headers;
+
+public class RNGeofenceWebhookConfiguration {
+    private String url;
+    private long timeout;
+    private ArrayList<Object> exclude;
+    private HashMap<String, Object> headersHashMap;
+
+    public RNGeofenceWebhookConfiguration(ReadableMap configuration) {
+        url = configuration.hasKey("url") ? configuration.getString("url") : null;
+        headersHashMap = configuration.hasKey("headers") ? configuration.getMap("headers").toHashMap() : new HashMap<String, Object>();
+        timeout = configuration.hasKey("timeout") ? configuration.getInt("timeout") : 15000;
+        exclude = configuration.hasKey("exclude") ? configuration.getArray("exclude").toArrayList() : new ArrayList<>();
+    }
+
+    public RNGeofenceWebhookConfiguration (JSONObject configuration) throws JSONException {
+        url = configuration.has("url") ? configuration.getString("url") : null;
+        timeout = configuration.has("timeout") ? configuration.getLong("timeout") : 15000;
+        headersHashMap = new HashMap<>();
+        exclude = new ArrayList<Object>();
+        JSONArray excludeJSONArray = configuration.has("exclude") ? configuration.getJSONArray("exclude") : new JSONArray();
+        JSONObject headersJSONObject = configuration.has("headers") ? configuration.getJSONObject("headers") : new JSONObject();
+        Iterator<String> hIterator = headersJSONObject.keys();
+        while(hIterator.hasNext()) {
+            String key = hIterator.next();
+            headersHashMap.put(key, headersJSONObject.getString(key));
+        }
+        for (int i = 0; i < excludeJSONArray.length(); i++) {
+            exclude.add(excludeJSONArray.getString(i));
+        }
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public long getTimeout() {
+        return timeout;
+    }
+
+    public ArrayList<Object> getExclude() {
+        return exclude;
+    }
+
+    public void save(Context context) {
+        RNGeofenceDB rnGeofenceDB = new RNGeofenceDB(context);
+        rnGeofenceDB.saveWebhookConfiguration(this);
+    }
+
+    public String toJSON() throws JSONException {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("url", url);
+        jsonObject.put("headers", new JSONObject(headersHashMap));
+        jsonObject.put("exclude", new JSONArray(exclude));
+        jsonObject.put("timeout", timeout);
+        return  jsonObject.toString();
+    }
+
+    public Headers getHeaders() {
+        Headers.Builder headerBuilder = new Headers.Builder();
+        Iterator hIterator = headersHashMap.entrySet().iterator();
+        while (hIterator.hasNext()) {
+            Map.Entry mapElement = (Map.Entry)hIterator.next();
+            String key = (String) mapElement.getKey();
+            String value = (String) mapElement.getValue();
+            if (key.toLowerCase().equals("content-type")) {
+                headersHashMap.remove(key);
+            } else {
+                headerBuilder.add(key, value);
+            }
+        }
+        headerBuilder.add("Content-Type", "application/json");
+        return headerBuilder.build();
+    }
+}

--- a/android/src/main/java/me/kiano/receivers/GeofenceBroadcastReceiver.java
+++ b/android/src/main/java/me/kiano/receivers/GeofenceBroadcastReceiver.java
@@ -5,8 +5,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
 
-import com.facebook.react.HeadlessJsTaskService;
-
 import me.kiano.services.GeofenceTransitionsJobIntentService;
 
 public class GeofenceBroadcastReceiver extends BroadcastReceiver {

--- a/android/src/main/java/me/kiano/receivers/OnDeviceRebootBroadcastReceiver.java
+++ b/android/src/main/java/me/kiano/receivers/OnDeviceRebootBroadcastReceiver.java
@@ -8,12 +8,6 @@ import android.os.Looper;
 import android.util.Log;
 import android.widget.Toast;
 
-import java.util.ArrayList;
-
-import me.kiano.database.GeofenceDB;
-import me.kiano.interfaces.RNGeofenceHandler;
-import me.kiano.models.RNGeofence;
-
 public class OnDeviceRebootBroadcastReceiver extends BroadcastReceiver {
     public static final String TAG = "RNBackgroundGeofencing";
     @Override

--- a/android/src/main/java/me/kiano/services/GeofenceWebhookWorker.java
+++ b/android/src/main/java/me/kiano/services/GeofenceWebhookWorker.java
@@ -47,14 +47,14 @@ public class GeofenceWebhookWorker extends Worker {
     @Override
     public Result doWork() {
         if (httpClient == null || rnGeofenceWebhookConfiguration == null) {
-            Log.v(TAG, "Failed some nice work");
+            Log.v(TAG, "Unable to call webhook. Missing configuration");
             return Result.success();
         }
         try {
-            Log.v(TAG, "Doing some nice work");
+            Log.v(TAG, "Started webhook work");
             String event = getInputData().getString("event");
             String data = getInputData().getString("data");
-            Log.v(TAG, "EVENT NAME: " + event);
+            Log.v(TAG, "Sending event: " + event);
             Log.v(TAG, data);
             ArrayList<Object> excludes = rnGeofenceWebhookConfiguration.getExclude();
             JSONObject jsonData = new JSONObject(data);

--- a/android/src/main/java/me/kiano/services/GeofenceWebhookWorker.java
+++ b/android/src/main/java/me/kiano/services/GeofenceWebhookWorker.java
@@ -1,0 +1,59 @@
+package me.kiano.services;
+
+import android.content.Context;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
+
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+public class GeofenceWebhookWorker extends Worker {
+
+    private final OkHttpClient httpClient = new OkHttpClient();
+
+    private String TAG = "GeofenceUploadWorker";
+
+    public GeofenceWebhookWorker(@NonNull Context context, @NonNull WorkerParameters params) {
+        super(context, params);
+    }
+
+    @Override
+    public Result doWork() {
+        Log.v(TAG, "Doing some nice work");
+        String EVENT_NAME = getInputData().getString("EVENT_NAME");
+        String EVENT_DATA = getInputData().getString("EVENT_DATA");
+        Log.v(TAG, "EVENT NAME: " + EVENT_NAME);
+        Log.v(TAG, EVENT_DATA);
+
+        RequestBody body = RequestBody.create(
+                MediaType.parse("application/json"),
+                EVENT_DATA
+        );
+
+        Request request = new Request.Builder()
+                .url("http://192.168.100.190:4000/geofence")
+                .addHeader("Kiano", "Man")
+                .post(body)
+                .build();
+
+        try {
+            Response response = httpClient.newCall(request).execute();
+            if (response.isSuccessful()) {
+                Log.e(TAG, "Request successfully sent status code: " + response.code());
+            } else {
+                Log.e(TAG, "Request failed with status code: " + response.code());
+            }
+        } catch (Exception e) {
+            Log.e(TAG, e.getMessage());
+        } finally {
+            return Result.success();
+        }
+
+    }
+}

--- a/android/src/main/java/me/kiano/services/OnGeoFenceEventJavaScriptTaskService.java
+++ b/android/src/main/java/me/kiano/services/OnGeoFenceEventJavaScriptTaskService.java
@@ -1,23 +1,11 @@
 package me.kiano.services;
 
-import android.app.ActivityManager;
-import android.app.Notification;
-import android.app.NotificationChannel;
-import android.app.NotificationManager;
-import android.content.Context;
-import android.content.Intent;
-import android.os.Build;
-import android.os.Bundle;
 import android.content.Intent;
 import android.os.Bundle;
-
-import androidx.core.app.NotificationCompat;
 
 import com.facebook.react.HeadlessJsTaskService;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.jstasks.HeadlessJsTaskConfig;
-
-import java.util.List;
 
 import javax.annotation.Nullable;
 

--- a/example/App.js
+++ b/example/App.js
@@ -1,18 +1,12 @@
 import React, {Component} from 'react';
 import {Platform, StyleSheet, Text, View, Button} from 'react-native';
-import BackgroundGeofencing, {
-  onGeofenceEvent,
-} from 'react-native-background-geofencing';
+import BackgroundGeofencing from 'react-native-background-geofencing';
 import {request, check, PERMISSIONS} from 'react-native-permissions';
 
 class App extends React.Component {
   constructor(props) {
     super(props);
     this.askPermissions();
-    onGeofenceEvent(async ({EVENT_NAME, EVENT_DATA}) => {
-      console.log('EVENT_NAME: ', EVENT_NAME);
-      console.log(EVENT_DATA);
-    });
   }
 
   askPermissions = async () => {

--- a/example/App.js
+++ b/example/App.js
@@ -46,12 +46,19 @@ class App extends React.Component {
     }
   };
 
+  removeGeofence = async () => {
+    BackgroundGeofencing.remove('kianoshome');
+  };
+
   render() {
     return (
       <View style={{flex: 1, alignItems: 'center', justifyContent: 'center'}}>
         <Text>Welcome to geofencing</Text>
         <View style={{marginTop: 15}}>
           <Button title="Start Geofence" onPress={this.startGeofence} />
+        </View>
+        <View style={{marginTop: 15}}>
+          <Button title="Remove Geofence" onPress={this.removeGeofence} />
         </View>
       </View>
     );

--- a/example/index.js
+++ b/example/index.js
@@ -5,5 +5,23 @@
 import {AppRegistry} from 'react-native';
 import App from './App';
 import {name as appName} from './app.json';
+import {configure} from 'react-native-background-geofencing';
+
+configure({
+  jsTask: ({EVENT_NAME, EVENT_DATA}) => {
+    console.log('---CLIENT---');
+    console.log(EVENT_NAME);
+    console.log(EVENT_DATA);
+    console.log('------------');
+  },
+  webhook: {
+    url: 'http://192.168.100.190:4000/geofence',
+    headers: {
+      foo: 'bar',
+    },
+    timeout: 20000,
+    exclude: ['altitude'],
+  },
+});
 
 AppRegistry.registerComponent(appName, () => App);

--- a/example/index.js
+++ b/example/index.js
@@ -8,10 +8,10 @@ import {name as appName} from './app.json';
 import {configure} from 'react-native-background-geofencing';
 
 configure({
-  jsTask: ({EVENT_NAME, EVENT_DATA}) => {
+  jsTask: async ({event, data}) => {
     console.log('---CLIENT---');
-    console.log(EVENT_NAME);
-    console.log(EVENT_DATA);
+    console.log(event);
+    console.log(data);
     console.log('------------');
   },
   webhook: {

--- a/index.js
+++ b/index.js
@@ -56,4 +56,10 @@ export default {
       throw error;
     }
   },
+
+  remove(geofenceId) {
+    if (typeof geofenceId === 'string') {
+      return BackgroundGeofencing.remove(geofenceId);
+    }
+  },
 };

--- a/index.js
+++ b/index.js
@@ -3,12 +3,33 @@ import {AppRegistry} from 'react-native';
 
 const {BackgroundGeofencing} = NativeModules;
 
-export const onGeofenceEvent = onGeofenceEventCallback => {
-  if (typeof onGeofenceEventCallback === 'function') {
-    AppRegistry.registerHeadlessTask(
-      'OnGeoFenceEventJavaScript',
-      () => onGeofenceEventCallback,
-    );
+const defaultWebhookConfiguration = {
+  url: null,
+  headers: null,
+  timeout: 15000,
+  exclude: [],
+};
+
+export const configure = (configuration = {}) => {
+  const {jsTask} = configuration;
+  let {webhook} = configuration;
+  if (jsTask && typeof jsTask !== 'function') {
+    throw new Error('invalid jsTask function provided');
+  }
+  if (webhook && typeof webhook !== 'object') {
+    throw new Error('invalid webhook configuration provided');
+  }
+  if (webhook && typeof webhook.url !== 'string') {
+    throw new Error('invalid webhook configuration provided');
+  }
+  if (jsTask) {
+    AppRegistry.registerHeadlessTask('OnGeoFenceEventJavaScript', () => jsTask);
+  }
+  if (webhook) {
+    BackgroundGeofencing.configureWebhook({
+      ...defaultWebhookConfiguration,
+      ...webhook,
+    });
   }
 };
 
@@ -21,7 +42,7 @@ export default {
       notificationResponsiveness: 0,
       loiteringDelay: 0,
       setDwellTransitionType: false,
-      initialiseOnDeviceRestart: false,
+      registerOnDeviceRestart: false,
       setInitialTriggers: true,
     };
     try {


### PR DESCRIPTION
- Use android work manager to schedule webhook calls, under network available constraints.
- Check for permissions before starting geofence
- Exposed a way to remove geofences from geofencing client and DB
- Renamed GeofenceDB to RNGeofenceDB as its not storing geofences alone but also webhook configurations
- Renamed `initialiseOnDeviceRestart` to `registerOnDeviceRestart` as thats what its literally doing.
- Defined a RNGeofenceWebhookConfiguration class model to handle config properties
- GeofenceTransitionsJobIntentService to start a work if there's a webhook config
- created GeofenceWebhookWorker to make webhook calls using RNGeofenceWebhookConfiguration model