### PR TITLE
Fix/service starts

### DIFF
--- a/android/src/main/java/me/kiano/services/RNDeviceRestartJobIntentService.java
+++ b/android/src/main/java/me/kiano/services/RNDeviceRestartJobIntentService.java
@@ -19,13 +19,14 @@ public class RNDeviceRestartJobIntentService extends JobIntentService {
 
     public static void enqueueWork(Context context, Intent work) {
         Log.v(TAG, "RNDeviceRestartJobIntentService called");
-        enqueueWork(context, RNDeviceRestartJobIntentService.class, 789, work);
+        enqueueWork(context, RNDeviceRestartJobIntentService.class, 665, work);
     }
 
     @Override
     protected void onHandleWork(@NonNull Intent intent) {
         RNGeofenceDB db = new RNGeofenceDB(getApplication());
         ArrayList<RNGeofence> storedGeofences = db.getAllGeofences();
+        Log.v(TAG, "RNDeviceRestartJobIntentService work started: " + storedGeofences.size());
         for (RNGeofence storedGeofence: storedGeofences) {
             storedGeofence.start(false, new RNGeofenceHandler() {
                 @Override

--- a/android/src/main/java/me/kiano/services/RNGeoFenceEventJavaScriptTaskService.java
+++ b/android/src/main/java/me/kiano/services/RNGeoFenceEventJavaScriptTaskService.java
@@ -1,19 +1,47 @@
 package me.kiano.services;
 
+import android.app.ActivityManager;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
+
+import androidx.core.app.NotificationCompat;
 
 import com.facebook.react.HeadlessJsTaskService;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.jstasks.HeadlessJsTaskConfig;
 
+import java.util.List;
+
 import javax.annotation.Nullable;
 
 public class RNGeoFenceEventJavaScriptTaskService extends HeadlessJsTaskService {
 
+    private static final String CHANNEL_ID = "RNBackgroundGeofencing";
+
     @Override
     public void onCreate() {
         super.onCreate();
+        if (!isAppOnForeground(getApplicationContext()) && android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+
+            int importance = NotificationManager.IMPORTANCE_DEFAULT;
+            NotificationChannel channel = new NotificationChannel(CHANNEL_ID, "RNBackgroundGeofencing", importance);
+            channel.setDescription("Background geofencing service");
+            NotificationManager notificationManager = getSystemService(NotificationManager.class);
+            notificationManager.createNotificationChannel(channel);
+
+            Notification notification = new NotificationCompat.Builder(this, CHANNEL_ID)
+                    .setContentTitle("Notification title")
+                    .setContentText("Notification title text")
+                    .setSmallIcon(getApplicationContext().getApplicationInfo().icon)
+                    .build();
+
+            startForeground(1, notification);
+        }
     }
 
     @Override
@@ -28,5 +56,23 @@ public class RNGeoFenceEventJavaScriptTaskService extends HeadlessJsTaskService 
             );
         }
         return null;
+    }
+
+    private boolean isAppOnForeground(Context context) {
+        ActivityManager activityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+        List<ActivityManager.RunningAppProcessInfo> appProcesses =
+                activityManager.getRunningAppProcesses();
+        if (appProcesses == null) {
+            return false;
+        }
+        final String packageName = context.getPackageName();
+        for (ActivityManager.RunningAppProcessInfo appProcess : appProcesses) {
+            if (appProcess.importance ==
+                    ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND &&
+                    appProcess.processName.equals(packageName)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/example/App.js
+++ b/example/App.js
@@ -38,7 +38,7 @@ class App extends React.Component {
         lat: -1.314683,
         lng: 36.836333,
         radius: 300,
-        initialiseOnDeviceRestart: true,
+        registerOnDeviceRestart: true,
       });
       console.log(addResult, 'addResult');
     } catch (error) {


### PR DESCRIPTION
This PR ensures that the Headless JS task and webhook pings will run no matter what 🔥

- Checks if app is in foreground or background then starts the Headless JS task on foreground or background depending on the context.

- RNDeviceRestartJobIntentService class re-registers stored geofences on device restart which then is received by the  RNGeofenceBroadcastReceiver which in turn kicks off a job to start webhook ping and run the Headless JS task in the foreground with a notification. 

Notification is static text which will be made customisable in next PR